### PR TITLE
Added new Cosmos based chains

### DIFF
--- a/src/config/ethereum.ts
+++ b/src/config/ethereum.ts
@@ -55,8 +55,7 @@ const chainConfig: Record<EVMChain, ChainConfig> = {
     chainId: "0x12c",
     chainName: "zkSync Sepolia",
     rpcUrls: ["https://sepolia.era.zksync.dev"],
-    explorerUrl: (hash: string) =>
-      `https://sepolia.explorer.zksync.io/tx/${hash}`,
+    explorerUrl: (hash: string) => `https://sepolia.explorer.zksync.io/tx/${hash}`,
     nativeCurrency: {
       name: "Ethereum",
       symbol: "ETH",
@@ -69,8 +68,7 @@ const chainConfig: Record<EVMChain, ChainConfig> = {
     chainId: "0x978",
     chainName: "zkSync Sepolia",
     rpcUrls: ["https://testnet.rpc.inevm.com/http"],
-    explorerUrl: (hash: string) =>
-      `https://inevm-testnet.explorer.caldera.xyz/tx/${hash}`,
+    explorerUrl: (hash: string) => `https://inevm-testnet.explorer.caldera.xyz/tx/${hash}`,
     nativeCurrency: {
       name: "Injective",
       symbol: "INJ",
@@ -120,8 +118,7 @@ const chainConfig: Record<EVMChain, ChainConfig> = {
     chainId: "0xAA37DC",
     chainName: "Optimism Sepolia",
     rpcUrls: ["https://sepolia.optimism.io"],
-    explorerUrl: (hash: string) =>
-      `https://sepolia-optimistic.etherscan.io/tx/${hash}`,
+    explorerUrl: (hash: string) => `https://sepolia-optimistic.etherscan.io/tx/${hash}`,
     nativeCurrency: {
       name: "Ether",
       symbol: "ETH",
@@ -138,6 +135,30 @@ const chainConfig: Record<EVMChain, ChainConfig> = {
     nativeCurrency: {
       name: "Ether",
       symbol: "ETH",
+      decimals: 18,
+    },
+  },
+  fantom: {
+    adamikChainId: "fantom",
+    chainId: "0xFA",
+    chainName: "Fantom",
+    rpcUrls: ["https://rpcapi.fantom.network"],
+    explorerUrl: (hash: string) => `https://ftmscan.com/tx/${hash}`,
+    nativeCurrency: {
+      name: "Fantom",
+      symbol: "FTM",
+      decimals: 18,
+    },
+  },
+  polygon: {
+    adamikChainId: "polygon",
+    chainId: "0x89",
+    chainName: "Polygon",
+    rpcUrls: ["https://polygon-rpc.com"],
+    explorerUrl: (hash: string) => `https://polygonscan.com//tx/${hash}`,
+    nativeCurrency: {
+      name: "MATIC",
+      symbol: "MATIC",
       decimals: 18,
     },
   },
@@ -163,9 +184,7 @@ export const getAdamikChainId = (chainId: EVMChain): string | undefined => {
   return undefined;
 };
 
-const getMetamaskConfig = (
-  chainId: EVMChain
-): Omit<ChainConfig, "adamikChainId"> | undefined => {
+const getMetamaskConfig = (chainId: EVMChain): Omit<ChainConfig, "adamikChainId"> | undefined => {
   if (chainConfig[chainId]) {
     return {
       chainId: chainConfig[chainId].chainId,
@@ -188,9 +207,7 @@ function getEVMChains(withoutTestnet = false): Chain[] {
   const chains = Object.entries(chainConfig);
 
   if (withoutTestnet) {
-    return chains
-      .filter(([, config]) => !config.isTestnet)
-      .map(([chainId]) => chainId as Chain);
+    return chains.filter(([, config]) => !config.isTestnet).map(([chainId]) => chainId as Chain);
   }
   return chains
     .sort(([, aConfig], [, bConfig]) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,13 @@ export type EVMChain =
   | "optimism"
   | "optimism-sepolia"
   | "arbitrum"
-  | "arbitrum-sepolia";
+  | "arbitrum-sepolia"
+  | "fantom"
+  | "polygon";
+// | "gnosis"
+// | "moonbeam"
+// | "moonriver"
+// | "palm";
 
 export type Token = {
   chainId: Chain;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Chain = "cosmoshub" | "algorand" | "osmosis" | EVMChain;
+export type Chain = "cosmoshub" | "algorand" | "osmosis" | "dydx" | "celestia" | "axelar" | EVMChain;
 
 export type EVMChain =
   | "ethereum"

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -33,6 +33,10 @@ export function getChainModes(chainId: Chain): Mode[] {
   switch (chainId) {
     case "cosmoshub":
     case "osmosis":
+    case "celestia":
+    //case "cosmoshub-testnet":
+    case "dydx":
+    case "axelar":
       return ["transfer", "delegate"];
     case "algorand":
     case "ethereum":
@@ -43,10 +47,8 @@ export function getChainModes(chainId: Chain): Mode[] {
     case "injective-testnet":
     case "base":
     case "base-sepolia":
-    case "optimism":
-    case "optimism-sepolia":
-    case "arbitrum":
-    case "arbitrum-sepolia":
+    case "optimism": //case "optimism-sepolia":
+    case "arbitrum": //case "arbitrum-sepolia":
       return ["transfer", "transferToken"];
     default:
       return ["transfer"];

--- a/src/wallets/KeplrWallet.ts
+++ b/src/wallets/KeplrWallet.ts
@@ -4,7 +4,7 @@ import { mintscanUrl } from "../utils/utils";
 
 export class KeplrWallet implements IWallet {
   public name = "Keplr";
-  public supportedChains: Chain[] = ["cosmoshub", "osmosis"];
+  public supportedChains: Chain[] = ["cosmoshub", "osmosis", "celestia", "dydx", "axelar"];
   public icon = "/icons/Keplr.svg";
   public unit = 6; // TODO: Get from Adamik ?
   public signFormat = "json";
@@ -12,6 +12,9 @@ export class KeplrWallet implements IWallet {
   private adamikNameConverted: { [k: string]: string } = {
     cosmoshub: "cosmoshub-4",
     osmosis: "osmosis-1",
+    dydx: "dydx-mainnet-1",
+    celestia: "celestia",
+    axelar: "axelar-dojo-1",
   };
   public withoutBroadcast: boolean = false;
 


### PR DESCRIPTION
- Added Axelar, DyDx, Celestia,
- Remove token transfer for arbitrum and optimism sepolia testnets (as not supported by indexers) 
- Added mapping between new cosmos chains and official network name